### PR TITLE
fresh install config page fix

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -6,7 +6,7 @@ Redmine::Plugin.register :a_common_libs do
   url 'http://rmplus.pro/'
   author_url 'http://rmplus.pro/'
 
-  settings :partial => 'settings/a_common_libs'
+  settings :default => {'empty' => true}, :partial => 'settings/a_common_libs'
 end
 
 Rails.application.config.to_prepare do


### PR DESCRIPTION
Without this, URL: /settings/plugin/a_common_libs is giving 500 error
